### PR TITLE
feat: implement external iteration

### DIFF
--- a/rle/interface.go
+++ b/rle/interface.go
@@ -20,5 +20,6 @@ type RunIterable interface {
 
 type BitIterator interface {
 	Next() (uint64, error)
+	Nth(n uint64) (uint64, error)
 	HasNext() bool
 }

--- a/rle/runs.go
+++ b/rle/runs.go
@@ -298,6 +298,9 @@ type normIter struct {
 }
 
 func newNormIter(it RunIterator) *normIter {
+	if nit, ok := it.(*normIter); ok {
+		return nit
+	}
 	return &normIter{
 		it: &peekIter{
 			it:    it,


### PR DESCRIPTION
As nice as internal iteration (ForEach) is for performance, it's impossible to iterate over two bitmaps at the same time with internal iteration. This patch:

* Adds external iteration functions: RunIterator and BitIterator.
* Adds an Nth function to BitIterator so we can quickly seek N forward.