### PR TITLE
optimize bitfield IsEmpty

### DIFF
--- a/bitfield.go
+++ b/bitfield.go
@@ -466,13 +466,17 @@ func (bf *BitField) First() (uint64, error) {
 
 // IsEmpty returns true if the bitset is empty.
 //
-// This operation's runtime is O(bits).
+// This operation's runtime is O(1).
 func (bf *BitField) IsEmpty() (bool, error) {
-	c, err := bf.Count()
-	if err != nil {
+	_, err := bf.First()
+	switch err {
+	case ErrNoBitsSet:
+		return true, nil
+	case nil:
+		return false, nil
+	default:
 		return false, err
 	}
-	return c == 0, nil
 }
 
 // Slice treats the BitField as an ordered set of set bits, then slices this set.

--- a/bitfield.go
+++ b/bitfield.go
@@ -161,7 +161,7 @@ func MultiMerge(bfs ...*BitField) (*BitField, error) {
 	return NewFromIter(iters[0])
 }
 
-func (bf BitField) sum() (rlepluslazy.RunIterator, error) {
+func (bf *BitField) sum() (rlepluslazy.RunIterator, error) {
 	iter, err := bf.rle.RunIterator()
 	if err != nil {
 		return nil, err
@@ -204,7 +204,7 @@ func (bf BitField) sum() (rlepluslazy.RunIterator, error) {
 //
 // This operation's runtime is O(1) up-front. However, it adds an O(bits
 // explicitly set) cost to all other operations.
-func (bf BitField) Set(bit uint64) {
+func (bf *BitField) Set(bit uint64) {
 	delete(bf.unset, bit)
 	bf.set[bit] = struct{}{}
 }
@@ -213,7 +213,7 @@ func (bf BitField) Set(bit uint64) {
 //
 // This operation's runtime is O(1). However, it adds an O(bits
 // explicitly unset) cost to all other operations.
-func (bf BitField) Unset(bit uint64) {
+func (bf *BitField) Unset(bit uint64) {
 	delete(bf.set, bit)
 	bf.unset[bit] = struct{}{}
 }
@@ -227,7 +227,7 @@ func (bf BitField) Unset(bit uint64) {
 // Count() will return 3.
 //
 // This operation's runtime is O(number of runs).
-func (bf BitField) Count() (uint64, error) {
+func (bf *BitField) Count() (uint64, error) {
 	s, err := bf.sum()
 	if err != nil {
 		return 0, err
@@ -246,7 +246,7 @@ func (bf BitField) Count() (uint64, error) {
 //     []uint64{0, 3}
 //
 // This operation's runtime is O(number of bits).
-func (bf BitField) All(max uint64) ([]uint64, error) {
+func (bf *BitField) All(max uint64) ([]uint64, error) {
 	c, err := bf.Count()
 	if err != nil {
 		return nil, xerrors.Errorf("count errror: %w", err)
@@ -279,7 +279,7 @@ func (bf BitField) All(max uint64) ([]uint64, error) {
 //     map[uint64]bool{0: true, 3: true}
 //
 // This operation's runtime is O(number of bits).
-func (bf BitField) AllMap(max uint64) (map[uint64]bool, error) {
+func (bf *BitField) AllMap(max uint64) (map[uint64]bool, error) {
 	c, err := bf.Count()
 	if err != nil {
 		return nil, xerrors.Errorf("count errror: %w", err)

--- a/bitfield.go
+++ b/bitfield.go
@@ -10,7 +10,10 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var ErrBitFieldTooMany = errors.New("to many items in RLE")
+var (
+	ErrBitFieldTooMany = errors.New("to many items in RLE")
+	ErrNoBitsSet       = errors.New("bitfield has no set bits")
+)
 
 type BitField struct {
 	rle rlepluslazy.RLE
@@ -435,7 +438,8 @@ func (bf *BitField) IsSet(x uint64) (bool, error) {
 	return rlepluslazy.IsSet(iter, x)
 }
 
-// First returns the index of the first set bit.
+// First returns the index of the first set bit. This function returns
+// ErrNoBitsSet when no bits have been set.
 //
 // This operation's runtime is O(1).
 func (bf *BitField) First() (uint64, error) {
@@ -457,7 +461,7 @@ func (bf *BitField) First() (uint64, error) {
 			i += r.Len
 		}
 	}
-	return 0, fmt.Errorf("bitfield has no set bits")
+	return 0, ErrNoBitsSet
 }
 
 // IsEmpty returns true if the bitset is empty.

--- a/bitfield_benchmark_test.go
+++ b/bitfield_benchmark_test.go
@@ -1,0 +1,66 @@
+package bitfield
+
+import (
+	"fmt"
+	"testing"
+)
+
+func benchmark(b *testing.B, cb func(b *testing.B, bf *BitField)) {
+	for _, size := range []int{
+		0,
+		1,
+		10,
+		1000,
+		1000000,
+	} {
+		benchmarkSize(b, size, cb)
+	}
+}
+
+func benchmarkSize(b *testing.B, size int, cb func(b *testing.B, bf *BitField)) {
+	b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+		vals := getRandIndexSet(size)
+		bf := NewFromSet(vals)
+		b.Run("basic", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				cb(b, bf)
+			}
+		})
+
+		if size < 1 {
+			return
+		}
+
+		// Set and unset some bits
+		i := uint64(size / 10)
+		bf.Set(i)
+		bf.Set(i + 1)
+		bf.Set(i * 2)
+		bf.Unset(i / 2)
+		bf.Unset(uint64(size) - 1)
+
+		b.Run("modified", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				cb(b, bf)
+			}
+		})
+	})
+}
+
+func BenchmarkCount(b *testing.B) {
+	benchmark(b, func(b *testing.B, bf *BitField) {
+		_, err := bf.Count()
+		if err != nil {
+			b.Fatal(err)
+		}
+	})
+}
+
+func BenchmarkIsEmpty(b *testing.B) {
+	benchmark(b, func(b *testing.B, bf *BitField) {
+		_, err := bf.IsEmpty()
+		if err != nil {
+			b.Fatal(err)
+		}
+	})
+}


### PR DESCRIPTION
This patch optimizes bitfield.IsEmpty to use First, instead of counting.

Unfortunately, it doesn't help all _that_ much because we're iterating up-front in the lazy RLE to cache the iterator. But it helps a bit.