### PR TITLE
Extract union logic to rlepluslazy sub-package

### DIFF
--- a/bitfield.go
+++ b/bitfield.go
@@ -141,27 +141,11 @@ func MultiMerge(bfs ...*BitField) (*BitField, error) {
 		iters = append(iters, iter)
 	}
 
-	for len(iters) > 1 {
-		var next []rlepluslazy.RunIterator
-
-		for i := 0; i < len(iters); i += 2 {
-			if i+1 >= len(iters) {
-				next = append(next, iters[i])
-				continue
-			}
-
-			orit, err := rlepluslazy.Or(iters[i], iters[i+1])
-			if err != nil {
-				return nil, err
-			}
-
-			next = append(next, orit)
-		}
-
-		iters = next
+	iter, err := rlepluslazy.Union(iters...)
+	if err != nil {
+		return nil, err
 	}
-
-	return NewFromIter(iters[0])
+	return NewFromIter(iter)
 }
 
 func (bf *BitField) RunIterator() (rlepluslazy.RunIterator, error) {

--- a/rle/merge.go
+++ b/rle/merge.go
@@ -1,0 +1,31 @@
+package rlepluslazy
+
+// Union returns the union of the passed iterators. Internally, this calls Or on
+// the passed iterators, combining them with a binary tree of Ors.
+func Union(iters ...RunIterator) (RunIterator, error) {
+	if len(iters) == 0 {
+		return RunsFromSlice(nil)
+	}
+
+	for len(iters) > 1 {
+		var next []RunIterator
+
+		for i := 0; i < len(iters); i += 2 {
+			if i+1 >= len(iters) {
+				next = append(next, iters[i])
+				continue
+			}
+
+			orit, err := Or(iters[i], iters[i+1])
+			if err != nil {
+				return nil, err
+			}
+
+			next = append(next, orit)
+		}
+
+		iters = next
+	}
+
+	return iters[0], nil
+}


### PR DESCRIPTION
This way this logic can be applied to arbitrary run iterators without having to re-materialize a bitfield in between operations.