### PR TITLE
notIter: Better number for infinity

### DIFF
--- a/rle/runs.go
+++ b/rle/runs.go
@@ -252,7 +252,7 @@ func (ni *notIter) NextRun() (Run, error) {
 	if !ni.it.HasNext() {
 		return Run{
 			Val: true,
-			Len: 10000000000, // close enough to infinity
+			Len: 40_000_000_000_000, // close enough to infinity
 		}, nil
 	}
 


### PR DESCRIPTION
The previous number wasn't close enough to infinity for my use case