### PR TITLE
Fix evaluation order bug

### DIFF
--- a/rle/bits.go
+++ b/rle/bits.go
@@ -40,7 +40,8 @@ func (it *it2b) Nth(n uint64) (uint64, error) {
 	}
 	it.run.Len -= skip
 	it.curIdx += skip
-	return it.curIdx - 1, it.prep()
+	res := it.curIdx - 1
+	return res, it.prep()
 }
 
 func (it *it2b) prep() error {

--- a/rle/bits_test.go
+++ b/rle/bits_test.go
@@ -44,7 +44,7 @@ func TestNthRuns(t *testing.T) {
 }
 
 func testIter(t *testing.T, ctor func(t *testing.T, bits []uint64) BitIterator) {
-	{
+	for i := 0; i < 10; i++ {
 		bits := randomBits(1000, 1500)
 		iter := ctor(t, bits)
 
@@ -72,7 +72,7 @@ func testIter(t *testing.T, ctor func(t *testing.T, bits []uint64) BitIterator) 
 
 		assert.Equal(t, bits[15:], remainingBits)
 	}
-	{
+	for i := 0; i < 10; i++ {
 		bits := randomBits(1000, 1500)
 		iter := ctor(t, bits)
 


### PR DESCRIPTION
Apparently, deterministic left to right evaluation order is just too much to ask from go.

https://golang.org/ref/spec#Order_of_evaluation