### PR TITLE
Minimally encode

### DIFF
--- a/rle/bitvec.go
+++ b/rle/bitvec.go
@@ -111,6 +111,7 @@ type wbitvec struct {
 	bitCap byte   // number of bits stored in temporary storage
 }
 
+// Returns the resulting bitvector, with any trailing zero bytes removed.
 func (bv *wbitvec) Out() []byte {
 	if bv.bitCap != 0 {
 		// if there are some bits in temporary storage we need to save them
@@ -122,6 +123,12 @@ func (bv *wbitvec) Out() []byte {
 	}
 	bv.bitCap = 0
 	bv.bits = 0
+
+	// Minimally encode.
+	for len(bv.buf) > 0 && bv.buf[len(bv.buf)-1] == 0 {
+		bv.buf = bv.buf[:len(bv.buf)-1]
+	}
+
 	return bv.buf
 }
 

--- a/rle/internal/rleplus/bitvector.go
+++ b/rle/internal/rleplus/bitvector.go
@@ -152,3 +152,21 @@ func (v *BitVector) Iterator(order BitNumbering) func(uint) byte {
 		return
 	}
 }
+
+// Trims zero bits from the end of the bit vector.
+func (v *BitVector) Trim() {
+	for v.Len > 0 {
+		idx := (v.Len - 1) / 8
+		bit := (v.Len - 1) % 8
+		b := v.Buf[idx]
+		if b&(1<<bit) != 0 {
+			return
+		}
+
+		// Trim.
+		v.Len--
+		if bit == 0 {
+			v.Buf = v.Buf[:len(v.Buf)-1]
+		}
+	}
+}

--- a/rle/rleplus_reader.go
+++ b/rle/rleplus_reader.go
@@ -5,6 +5,11 @@ import (
 )
 
 func DecodeRLE(buf []byte) (RunIterator, error) {
+	if len(buf) > 0 && buf[len(buf)-1] == 0 {
+		// trailing zeros bytes not allowed.
+		return nil, xerrors.Errorf("not minimally encoded: %w", ErrDecode)
+	}
+
 	bv := readBitvec(buf)
 
 	ver := bv.Get(2) // Read version


### PR DESCRIPTION
Always minimally encode bitvectors by stripping trailing zero bytes. We assume infinitely many trailing zero bits when decoding.

This also fixes an issue where uninitialized bitvectors would be empty while (introduced in #37) while initialized but empty bitvectors would encode to a single byte. Now, empty bitvectors always encode to no bytes (until we
increase the version number).

Finally, this _rejects_ bitfields that are not minimally encoded (have trailing zero bytes).

Note: this changes the encoding for more than just uninitialized/zero-length bitfields. Any bitfield that would have a trailing zero byte no longer has one.