### PR TITLE
Allow up to cbor-gen max byte array size

### DIFF
--- a/bitfield.go
+++ b/bitfield.go
@@ -404,7 +404,7 @@ func (bf *BitField) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	if len(rle) > 8192 {
+	if len(rle) > cbg.ByteArrayMaxLen {
 		return xerrors.Errorf("encoded bitfield was too large (%d)", len(rle))
 	}
 
@@ -424,7 +424,7 @@ func (bf *BitField) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if extra > 8192 {
+	if extra > cbg.ByteArrayMaxLen {
 		return fmt.Errorf("array too large")
 	}
 


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/specs-actors/issues/676

This is currently 2MiB. Honestly, that's kind of ridiculous and we should likely set cbor-gen's limit to be smaller.

----

#