### PR TITLE
Lower the max encoded limit

### DIFF
--- a/bitfield.go
+++ b/bitfield.go
@@ -15,6 +15,12 @@ var (
 	ErrNoBitsSet       = errors.New("bitfield has no set bits")
 )
 
+// MaxEncodedSize is the maximum encoded size of a bitfield. When expanded into
+// a slice of runs, a bitfield of this size should not exceed 2MiB of memory.
+//
+// This bitfield can fit at least 3072 sparse elements.
+const MaxEncodedSize = 32 << 10
+
 type BitField struct {
 	rle rlepluslazy.RLE
 
@@ -404,7 +410,7 @@ func (bf *BitField) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	if len(rle) > cbg.ByteArrayMaxLen {
+	if len(rle) > MaxEncodedSize {
 		return xerrors.Errorf("encoded bitfield was too large (%d)", len(rle))
 	}
 
@@ -424,7 +430,7 @@ func (bf *BitField) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if extra > cbg.ByteArrayMaxLen {
+	if extra > MaxEncodedSize {
 		return fmt.Errorf("array too large")
 	}
 


### PR DESCRIPTION
After further consideration, the max byte array length doesn't make sense because we'll expand the bitfield in memory. The new limit, 32KiB, will expand to at most 4MiB in memory (assuming alternating length-1 runs of 0 and 1).