### PR TITLE
Add BitField.Last

### DIFF
--- a/bitfield.go
+++ b/bitfield.go
@@ -551,6 +551,37 @@ func (bf *BitField) First() (uint64, error) {
 	return 0, ErrNoBitsSet
 }
 
+// Last returns the index of the last set bit. This function returns
+// ErrNoBitsSet when no bits have been set.
+//
+// This operation's runtime is O(n).
+func (bf *BitField) Last() (uint64, error) {
+	iter, err := bf.RunIterator()
+	if err != nil {
+		return 0, err
+	}
+
+	var (
+		at, maxplusone uint64
+	)
+	for iter.HasNext() {
+		run, err := iter.NextRun()
+		if err != nil {
+			return 0, err
+		}
+
+		at += run.Len
+
+		if run.Val {
+			maxplusone = at
+		}
+	}
+	if maxplusone == 0 {
+		return 0, ErrNoBitsSet
+	}
+	return maxplusone - 1, nil
+}
+
 // IsEmpty returns true if the bitset is empty.
 //
 // This operation's runtime is O(1).

--- a/bitfield_test.go
+++ b/bitfield_test.go
@@ -750,3 +750,18 @@ func TestBitfieldCutSame(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, count)
 }
+
+func TestLast(t *testing.T) {
+	bits := getRandIndexSetSeed(100, 1)
+	bf := NewFromSet(bits)
+	last, err := bf.Last()
+	require.NoError(t, err)
+
+	assert.Equal(t, last, bits[len(bits)-1])
+}
+
+func TestLastEmpty(t *testing.T) {
+	bf := NewFromSet(nil)
+	_, err := bf.Last()
+	require.EqualError(t, err, ErrNoBitsSet.Error())
+}

--- a/rle/runs.go
+++ b/rle/runs.go
@@ -347,39 +347,29 @@ func (it *normIter) NextRun() (Run, error) {
 	return it.it.NextRun()
 }
 
-func LastIndex(iter RunIterator, val bool) (uint64, error) {
-	var at uint64
-	var max uint64
+// Returns iterator with all bits up to the last bit set:
+// in:  11100000111010001110000
+// out: 1111111111111111111
+func Fill(iter RunIterator) (RunIterator, error) {
+	var at, length uint64
 	for iter.HasNext() {
 		r, err := iter.NextRun()
 		if err != nil {
-			return 0, err
+			return nil, err
 		}
 
 		at += r.Len
 
-		if r.Val == val {
-			max = at
+		if r.Val {
+			length = at
 		}
 	}
 
-	return max, nil
-}
-
-// Returns iterator with all bits up to the last bit set:
-// in:  11100000111010001110000
-// out: 1111111111111111111
-func Fill(i RunIterator) (RunIterator, error) {
-	max, err := LastIndex(i, true)
-	if err != nil {
-		return nil, err
-	}
-
 	var runs []Run
-	if max > 0 {
+	if length > 0 {
 		runs = append(runs, Run{
 			Val: true,
-			Len: max,
+			Len: length,
 		})
 	}
 

--- a/rle/runs_test.go
+++ b/rle/runs_test.go
@@ -157,3 +157,34 @@ func TestCount(t *testing.T) {
 		})
 	}
 }
+
+func TestFill(t *testing.T) {
+	N := 100
+	for i := 0; i < N; i++ {
+		abits := randomBits(1000, 1500)
+
+		iter, err := RunsFromSlice(abits)
+		assert.NoError(t, err)
+
+		iter2, err := Fill(iter)
+		assert.NoError(t, err)
+
+		count, err := Count(iter2)
+		assert.NoError(t, err)
+
+		assert.Equal(t, abits[len(abits)-1], count-1)
+	}
+}
+
+func TestFillEmpty(t *testing.T) {
+	iter, err := RunsFromSlice(nil)
+	assert.NoError(t, err)
+
+	iter2, err := Fill(iter)
+	assert.NoError(t, err)
+
+	count, err := Count(iter2)
+	assert.NoError(t, err)
+
+	assert.Zero(t, count)
+}


### PR DESCRIPTION
1. Add a Last function to the bitfield to type to get the last set bit. This can be useful to quickly check to see if all set bits are within an acceptable range.
2. Merge `LastIndex` into `Fill` as `LastIndex` doesn't actually return the index of the last bit set (it returns index + 1). Fixing `LastIndex` would be awkward as we'd have to return an error when empty, then check for the specific error in `Fill`.
