### PR TITLE
Optimize RLE+ Validation by specialized decoder

### DIFF
--- a/bitfield_benchmark_test.go
+++ b/bitfield_benchmark_test.go
@@ -99,6 +99,20 @@ func BenchmarkBigDecodeEncode(b *testing.B) {
 	}
 }
 
+func BenchmarkBigValidate(b *testing.B) {
+	bb, err := base64.StdEncoding.DecodeString(bigBitfield)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		bitF, err := NewFromBytes(bb)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, _ = bitF.RunIterator()
+	}
+}
+
 func bitfieldStats(t *testing.T, bf BitField) (size int, runs uint64, last uint64) {
 	s, err := bf.RunIterator()
 	if err != nil {

--- a/bitfield_benchmark_test.go
+++ b/bitfield_benchmark_test.go
@@ -1,6 +1,7 @@
 package bitfield
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"testing"
@@ -104,12 +105,48 @@ func BenchmarkBigValidate(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		bitF, err := NewFromBytes(bb)
 		if err != nil {
 			b.Fatal(err)
 		}
 		_, _ = bitF.RunIterator()
+	}
+}
+
+func BenchmarkBigAllocateSector(b *testing.B) {
+	bb, err := base64.StdEncoding.DecodeString(bigBitfield)
+	if err != nil {
+		b.Fatal(err)
+	}
+	sectorNo := uint64(0)
+	{
+		bitF, err := NewFromBytes(bb)
+		if err != nil {
+			b.Fatal(err)
+		}
+		last, err := bitF.Last()
+		if err != nil {
+			b.Fatal(err)
+		}
+		sectorNo = last + 10
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bitF, err := NewFromBytes(bb)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = bitF.IsSet(sectorNo)
+		if err != nil {
+			b.Fatal(err)
+		}
+		bitF.Set(sectorNo)
+		err = bitF.MarshalCBOR(&bytes.Buffer{})
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/rle/rleplus.go
+++ b/rle/rleplus.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 
 	"golang.org/x/xerrors"
 )
@@ -41,23 +40,7 @@ func (rle *RLE) Bytes() []byte {
 // Validate is a separate function to show up on profile for repeated decode evaluation
 func (rle *RLE) Validate() error {
 	if !rle.validated {
-		source, err := DecodeRLE(rle.buf)
-		if err != nil {
-			return xerrors.Errorf("decoding RLE: %w", err)
-		}
-		var length uint64
-
-		for source.HasNext() {
-			r, err := source.NextRun()
-			if err != nil {
-				return xerrors.Errorf("reading run: %w", err)
-			}
-			if math.MaxUint64-r.Len < length {
-				return xerrors.New("RLE+ overflows")
-			}
-			length += r.Len
-		}
-		rle.validated = true
+		return ValidateRLE(rle.buf)
 	}
 	return nil
 }

--- a/rle/rleplus_reader.go
+++ b/rle/rleplus_reader.go
@@ -77,6 +77,7 @@ func DecodeRLE(buf []byte) (RunIterator, error) {
 	return it, nil
 }
 
+// ValidateRLE validates the RLE+ in buf does not overflow Uint64
 func ValidateRLE(buf []byte) error {
 	if len(buf) > 0 && buf[len(buf)-1] == 0 {
 		// trailing zeros bytes not allowed.
@@ -88,6 +89,8 @@ func ValidateRLE(buf []byte) error {
 	if ver != Version {
 		return ErrWrongVersion
 	}
+
+	// this is run value bit, as we are validating lengths we don't care about it
 	bv.Get(1)
 
 	totalLen := uint64(0)


### PR DESCRIPTION
Benchmark:
```
Count/0/basic-8              193ns ± 7%   122ns ±16%  -36.72%  (p=0.008 n=5+5)
Count/1/basic-8              211ns ± 8%   134ns ± 3%  -36.28%  (p=0.008 n=5+5)
Count/1/modified-8           858ns ± 5%   772ns ± 6%  -10.00%  (p=0.008 n=5+5)
Count/10/basic-8             356ns ± 5%   242ns ± 3%  -31.97%  (p=0.008 n=5+5)
Count/10/modified-8         1.42µs ± 3%  1.21µs ± 4%  -14.53%  (p=0.008 n=5+5)
Count/1000/basic-8          23.3µs ± 5%  15.0µs ± 0%  -35.52%  (p=0.008 n=5+5)
Count/1000/modified-8       45.8µs ± 2%  37.1µs ± 0%  -19.02%  (p=0.016 n=5+4)
Count/1000000/basic-8       24.7ms ± 2%  17.3ms ± 2%  -29.94%  (p=0.008 n=5+5)
Count/1000000/modified-8    44.1ms ± 0%  36.9ms ± 0%  -16.42%  (p=0.016 n=5+4)
IsEmpty/0/basic-8            191ns ± 9%   127ns ± 7%  -33.72%  (p=0.008 n=5+5)
IsEmpty/1/basic-8            206ns ± 4%   137ns ± 5%  -33.53%  (p=0.008 n=5+5)
IsEmpty/1/modified-8         889ns ± 5%   830ns ± 9%     ~     (p=0.095 n=5+5)
IsEmpty/10/basic-8           298ns ± 3%   184ns ± 6%  -38.32%  (p=0.008 n=5+5)
IsEmpty/10/modified-8       1.17µs ±11%  1.05µs ± 5%  -10.55%  (p=0.032 n=5+5)
IsEmpty/1000/basic-8        11.2µs ± 4%   4.3µs ± 2%  -61.51%  (p=0.008 n=5+5)
IsEmpty/1000/modified-8     12.0µs ± 0%   5.3µs ± 1%  -55.90%  (p=0.016 n=4+5)
IsEmpty/1000000/basic-8     12.1ms ± 2%   4.8ms ± 2%  -59.98%  (p=0.008 n=5+5)
IsEmpty/1000000/modified-8  11.9ms ± 3%   4.7ms ± 0%  -60.21%  (p=0.016 n=5+4)
BigDecodeEncode-8            756µs ± 3%   600µs ± 2%  -20.54%  (p=0.008 n=5+5)
BigValidate-8                278µs ± 3%   130µs ± 3%  -53.29%  (p=0.008 n=5+5)
```