### PR TITLE
return a better "infinity" from notIter.NextRun

### DIFF
--- a/bitfield_benchmark_test.go
+++ b/bitfield_benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"math"
 	"testing"
 
 	rlepluslazy "github.com/filecoin-project/go-bitfield/rle"
@@ -233,4 +234,17 @@ func BenchmarkMultiMergeEmpty(b *testing.B) {
 		_, _ = merged.RunIterator()
 	}
 
+}
+
+func BenchmarkBitfieldSubtractLargeElement(b *testing.B) {
+	bfa := NewFromSet([]uint64{1, 2, math.MaxUint64 - 1})
+	bfb := NewFromSet([]uint64{1})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := SubtractBitField(bfa, bfb)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/bitfield_test.go
+++ b/bitfield_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/rand"
 	"sort"
 	"testing"
@@ -453,6 +454,24 @@ func TestBitfieldSubtract(t *testing.T) {
 		fmt.Println(out)
 		fmt.Println(exp)
 		t.Fatal("subtraction is wrong")
+	}
+}
+func TestBitfieldSubtractLargeElement(t *testing.T) {
+	bfa := NewFromSet([]uint64{1, 2, math.MaxUint64 - 1})
+	bfb := NewFromSet([]uint64{1})
+
+	inter, err := SubtractBitField(bfa, bfb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := inter.All(10000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slicesEqual(out, []uint64{2, math.MaxUint64 - 1}) {
+		t.Fatalf("subtraction is wrong: %v", out)
 	}
 }
 

--- a/rle/runs.go
+++ b/rle/runs.go
@@ -260,9 +260,10 @@ func (ni *notIter) HasNext() bool {
 
 func (ni *notIter) NextRun() (Run, error) {
 	if !ni.it.HasNext() {
+		// At this point, we'll keep returning "infinite" runs of true.
 		return Run{
 			Val: true,
-			Len: 40_000_000_000_000, // close enough to infinity
+			Len: math.MaxUint64,
 		}, nil
 	}
 


### PR DESCRIPTION
Otherwise, `Subtract({1, LargeSectorNumber}, {1})` can take a while (~4ms). It's now about 2000x faster.