### PR TITLE
polish: include rle count in marshaled json

### DIFF
--- a/bitfield_test.go
+++ b/bitfield_test.go
@@ -213,6 +213,16 @@ func TestBitfieldJson(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	bfCount, err := bf.Count()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert the count is the same in the unmarshalled bitfield and original
+	if bfCount != buf.Count {
+		t.Fatal(err)
+	}
+
 	// (0) (1) (2, 3, 4), (5, 6, 7), (8, 9), (10, 11, 12), (13, 14), 15
 	runs := []uint64{1, 1, 3, 3, 2, 3, 2, 1}
 	if !slicesEqual(runs, buf.RLE) {

--- a/bitfield_test.go
+++ b/bitfield_test.go
@@ -205,14 +205,17 @@ func TestBitfieldJson(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var buf []uint64
+	var buf = struct {
+		Count uint64
+		RLE   []uint64
+	}{}
 	if err := json.Unmarshal(b, &buf); err != nil {
 		t.Fatal(err)
 	}
 
 	// (0) (1) (2, 3, 4), (5, 6, 7), (8, 9), (10, 11, 12), (13, 14), 15
 	runs := []uint64{1, 1, 3, 3, 2, 3, 2, 1}
-	if !slicesEqual(runs, buf) {
+	if !slicesEqual(runs, buf.RLE) {
 		t.Fatal("runs not encoded correctly")
 	}
 }
@@ -260,6 +263,20 @@ func TestBitfieldJsonRoundTrip(t *testing.T) {
 	var out BitField
 	if err := out.UnmarshalJSON(b); err != nil {
 		t.Fatal(err)
+	}
+
+	bfCount, err := bf.Count()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outCount, err := out.Count()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bfCount != outCount {
+		t.Fatalf("round trip failed")
 	}
 
 	outv, err := out.All(100000)

--- a/rle/rleplus.go
+++ b/rle/rleplus.go
@@ -67,6 +67,11 @@ func (rle *RLE) Count() (uint64, error) {
 	return Count(it)
 }
 
+type jsonRes struct {
+	Count uint64
+	RLE   []uint64
+}
+
 // Encoded as an array of run-lengths, always starting with zeroes (absent values)
 // E.g.: The set {0, 1, 2, 8, 9} is the bitfield 1110000011, and would be marshalled as [0, 3, 5, 2]
 func (rle *RLE) MarshalJSON() ([]byte, error) {
@@ -80,10 +85,7 @@ func (rle *RLE) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	var ret = struct {
-		Count uint64
-		RLE   []uint64
-	}{}
+	var ret = jsonRes{}
 	if r.HasNext() {
 		first, err := r.NextRun()
 		if err != nil {
@@ -111,10 +113,7 @@ func (rle *RLE) MarshalJSON() ([]byte, error) {
 }
 
 func (rle *RLE) UnmarshalJSON(b []byte) error {
-	var buf = struct {
-		Count uint64
-		RLE   []uint64
-	}{}
+	var buf = jsonRes{}
 
 	if err := json.Unmarshal(b, &buf); err != nil {
 		return err

--- a/rle/rleplus.go
+++ b/rle/rleplus.go
@@ -75,16 +75,24 @@ func (rle *RLE) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	var ret []uint64
+	count, err := rle.Count()
+	if err != nil {
+		return nil, err
+	}
+
+	var ret = struct {
+		Count uint64
+		RLE   []uint64
+	}{}
 	if r.HasNext() {
 		first, err := r.NextRun()
 		if err != nil {
 			return nil, err
 		}
 		if first.Val {
-			ret = append(ret, 0)
+			ret.RLE = append(ret.RLE, 0)
 		}
-		ret = append(ret, first.Len)
+		ret.RLE = append(ret.RLE, first.Len)
 
 		for r.HasNext() {
 			next, err := r.NextRun()
@@ -92,17 +100,21 @@ func (rle *RLE) MarshalJSON() ([]byte, error) {
 				return nil, err
 			}
 
-			ret = append(ret, next.Len)
+			ret.RLE = append(ret.RLE, next.Len)
 		}
 	} else {
-		ret = []uint64{0}
+		ret.RLE = []uint64{0}
 	}
+	ret.Count = count
 
 	return json.Marshal(ret)
 }
 
 func (rle *RLE) UnmarshalJSON(b []byte) error {
-	var buf []uint64
+	var buf = struct {
+		Count uint64
+		RLE   []uint64
+	}{}
 
 	if err := json.Unmarshal(b, &buf); err != nil {
 		return err
@@ -110,7 +122,7 @@ func (rle *RLE) UnmarshalJSON(b []byte) error {
 
 	runs := []Run{}
 	val := false
-	for i, v := range buf {
+	for i, v := range buf.RLE {
 		if v == 0 {
 			if i != 0 {
 				return xerrors.New("Cannot have a zero-length run except at start")


### PR DESCRIPTION
### Motivation
This change allows users to inspect the number of elements present in a JSON marshaled RLE bitfield without decoding it. If there is another way to achieve this I'd be happy to do that instead.


A specific use case exists in Lily where we marshal message params to JSON and perform analysis on the data. For example, when inspecting a TerminatedSectors message, we generally want to see the number of sectors terminated; this change permits such inspection without the need to decode the bitfield ourselves. 